### PR TITLE
Updated "Computing Return Types"

### DIFF
--- a/doc/mp11/examples.adoc
+++ b/doc/mp11/examples.adoc
@@ -402,7 +402,7 @@ What this does is basically calls `std::visit` to do the work, but instead of pa
 it converts the result to a common type `R`. `R` is supposed to be `std::variant<...>` where the ellipsis denotes the return types of
 calling `f` with all possible combinations of variant values.
 
-We'll first define a helper quoted metafunction `Qret<F>` that returns the result of the application of `F` to arguments of type `T...`:
+We'll first define a helper quoted metafunction `Qret<F>` that returns the result of the application of `F` to arguments of type `T...`: 
 
     template<class F> struct Qret
     {
@@ -410,21 +410,23 @@ We'll first define a helper quoted metafunction `Qret<F>` that returns the resul
             decltype( std::declval<F>()( std::declval<T>()... ) );
     };
 
-(Unfortunately, we can't just define this metafunction inside `rvisit`; the language prohibits defining template aliases inside functions.)
+Unfortunately, we can't just define this metafunction inside `rvisit`; the language prohibits defining template aliases inside functions.  But we can make use of another C++17 feature to overcome this, and simplify the implementation further:
+
+    using Qret = mp_bind_front<std::invoke_result_t, F>;
 
 With `Qret` in hand, a `variant` of the possible return types is just a matter of applying it over the possible combinations of the variant values:
 
-    using R = mp_product_q<Qret<F>, std::remove_reference_t<V>...>;
+    using R = mp_product_q<Qret<F>, std::decay_t<V>...>;
 
 Why does this work? `mp_product<F, L1<T1...>, L2<T2...>, ..., Ln<Tn...>>` returns `L1<F<U1, U2, ..., Un>, ...>`, where `Ui` traverse all
 possible combinations of list values. Since in our case all `Li` are `std::variant`, the result will also be `std::variant`. (`mp_product_q` is
-the same as `mp_product`, but for quoted metafunctions such as our `Qret<F>`.)
+the same as `mp_product`, but for quoted metafunctions such as our `Qret<F>`.)   We needed to use `std::decay_t` for precisely the same reason as in the [Fixing `tuple_cat` example](#fixing_tuple_cat), where `std::decay_t` is similar to our `remove_cv_ref` (either can be used).
 
 One more step remains. Suppose that, as above, we're passing two variants of type `std::variant<short, int, float>` and `F` is
 `[]( auto const& x, auto const& y ){ return x + y; }`. This will generate `R` of length 9, one per each combination, but many of those
 elements will be the same, either `int` or `float`, and we need to filter out the duplicates. So, we pass the result to `mp_unique`:
 
-    using R = mp_unique<mp_product_q<Qret<F>, std::remove_reference_t<V>...>>;
+    using R = mp_unique<mp_product_q<Qret<F>, std::decay_t<V>...>>;
 
 and we're done:
 
@@ -438,15 +440,11 @@ and we're done:
 
 using namespace boost::mp11;
 
-template<class F> struct Qret
-{
-    template<class... T> using fn =
-        decltype( std::declval<F>()( std::declval<T>()... ) );
-};
 
 template<class F, class... V> auto rvisit( F&& f, V&&... v )
 {
-    using R = mp_unique<mp_product_q<Qret<F>, std::remove_reference_t<V>...>>;
+    using Qret = mp_bind_front<std::invoke_result_t, F>;
+    using R = mp_unique<mp_product_q<Qret, std::decay_t<V>...>>;
 
     return std::visit( [&]( auto&&... x )
         { return R( std::forward<F>(f)( std::forward<decltype(x)>(x)... ) ); },


### PR DESCRIPTION
- Suggest the use of `std::invoke_result` as an in place  alternative for `Qret`.
- Fix a bug with `const variant` calls, using `std::decay_t` instead of `std::remove_reference_t`.